### PR TITLE
Add traceback signal handler

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,19 @@
 import requests
 import json
+import signal
 import sys
 import faulthandler
 from rocket_alert_api import RocketAlertAPI
 from message_manager import MessageManager
 
+def dump_traceback(sig, frame):
+    print("\nReceived signal to dump traceback")
+    faulthandler.dump_traceback()
+
 def main():
     faulthandler.enable()
+    signal.signal(signal.SIGUSR1, dump_traceback)
+
     messageManager = MessageManager()
     print("Connecting to server and starting listening to events...")
 

--- a/script/dump_traceback.sh
+++ b/script/dump_traceback.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+python_pid=$(ps aux | grep '[p]ython' | awk '{print $1}' | head -n 1)
+
+echo "python pid is: $python_pid, going to send SIGUSR1 to the process to get traceback"
+kill -SIGUSR1 $python_pid
+echo "done, goodbye!"


### PR DESCRIPTION
Whenever traceback dump is needed, simply invoke `script/dump_traceback.sh` (then look at the process stderr)