### PR TITLE
Only listen to server-default alerts

### DIFF
--- a/rocket_alert_api.py
+++ b/rocket_alert_api.py
@@ -13,4 +13,4 @@ class RocketAlertAPI:
         }
 
     def listenToServerEvents(self):
-        return requests.get(f"{self.baseURL}/real-time?alertTypeId=-1", headers=self.headers, stream=True, timeout=120)
+        return requests.get(f"{self.baseURL}/real-time", headers=self.headers, stream=True, timeout=120)


### PR DESCRIPTION
This PR removes the `alertTypeId` parameter when calling the `real-time` endpoint, to support the changes on the server. With this change, the bot would only post messages when there are incoming server alerts of default type (i.e. either rockets or UAV alerts).